### PR TITLE
Add <functional> include.

### DIFF
--- a/python.cc
+++ b/python.cc
@@ -1,6 +1,7 @@
 // fix inttypes for GCC
 #define __STDC_FORMAT_MACROS
 #include <memory>
+#include <functional>
 #include <string>
 #include <unordered_map>
 #include <Python.h>


### PR DESCRIPTION
When using this in linux, I've found I hit this issue here: https://github.com/dmlc/xgboost/pull/2256. Adding this include seems to fix it.