### PR TITLE
Fix cached centroid bug

### DIFF
--- a/wmd/__init__.py
+++ b/wmd/__init__.py
@@ -528,7 +528,7 @@ class WMD(object):
             keys, centroids = self._centroid_cache
             dists = numpy.linalg.norm(centroids - avg, axis=-1)
             queue = [(None, k) for k in keys[numpy.argsort(dists)]
-                     if k is not None]
+                     if k is not None and k != index]
         self._log.info("%.1f", time() - ts)
         self._log.info("First K WMD")
         ts = time()


### PR DESCRIPTION
If applied, when calculating the centroid distances for a string origin/index while the centroids have already been cached, the origin is excluded from the resulting queue (which it wasn't before, causing kNN to return the query in results)